### PR TITLE
Fixed typo on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 #### Clone and run
 
 ```
-git clone https://github.com/WinterSunset/WhatsGo
+git clone https://github.com/WinterSunset95/WhatsGo
 ``` 
 
 ```


### PR DESCRIPTION
Took me longer than I care to admit to figure out why `git clone` wasn't working